### PR TITLE
[all] Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.9.0 (2019-09-28)
 
 - **[Breaking change]** Update to `avm1-types@0.9` (former `avm1-tree`).
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avm1-emitter",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "AVM1 files emitter",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Breaking change]** Update to `avm1-types@0.9` (former `avm1-tree`).