### PR TITLE
[all] Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.11.0 (2020-09-07)
 
 - **[Breaking change]** Update to `avm1-types@0.11`.
 
@@ -7,7 +7,7 @@
 - **[Breaking change]** Update to native ESM.
 - **[Internal]** Switch from `tslint` to `eslint`.
 
-# 0.10.0 (2020-10-23)
+# 0.10.0 (2020-02-23)
 
 - **[Breaking change]** Update to `avm1-types@0.10`.
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avm1-emitter",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "AVM1 files emitter",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
- **[Breaking change]** Update to `avm1-types@0.11`.

## TypeScript

- **[Breaking change]** Update to native ESM.
- **[Internal]** Switch from `tslint` to `eslint`.